### PR TITLE
allow symfony/cache ^4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "symfony/cache": "^5.0|^6.0",
+        "symfony/cache": "^4.4|^5.0|^6.0",
         "twig/twig": "^2.4|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
I didn't found any dependencies **not** in 4.4 LTS branch, so I've added symfony/cache:^4.4 wich works properly in our application with my personal fork.